### PR TITLE
Bewerted Version

### DIFF
--- a/ModSimWS1718Uebung03.ipynb
+++ b/ModSimWS1718Uebung03.ipynb
@@ -159,7 +159,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Der Fehler tritt auf, weil man Floatzahlen verschieden darstellen kann, daraus folgt, dass bei einer Repräsentation Fehler auftreten können. Die Grenze zwischen darstellbaren Zahlen liegt irgendwo zwischen 1.465456557-1.0 und 1.465456556-1.0."
+    "Der Fehler tritt auf, weil man Floatzahlen verschieden darstellen kann, daraus folgt, dass bei einer Repräsentation Fehler auftreten können. Die Grenze zwischen darstellbaren Zahlen liegt irgendwo zwischen 1.465456557-1.0 und 1.465456556-1.0.#"
    ]
   },
   {


### PR DESCRIPTION
Af3. 
"weil man Floatzahlen verschieden darstellen kann,"... ich befürchte du das vielleicht mistverstanden hast, weil eine Floatzahl sehr wahrscheinlich keine genaue Darstellung in Binär hat, also sie muss verschieden dargestellt wird. Keine Wahl wird man gegeben. 

"Die Grenze zwischen darstellbaren Zahlen liegt irgendwo zwischen 1.465456557-1.0 und 1.465456556-1.0" Die Grenze liegt eingentlich an 2−52. Mal anschauen an diese Beispiele: https://en.wikipedia.org/wiki/Double-precision_floating-point_format#Double-precision_examples